### PR TITLE
Make sure transformer return past_key_values

### DIFF
--- a/rl4lms/envs/text_generation/policy/causal_policy.py
+++ b/rl4lms/envs/text_generation/policy/causal_policy.py
@@ -103,6 +103,10 @@ class CausalLMActorCriticPolicy(LMActorCriticPolicy, ActorCriticWarmStartMixin):
             input_ids, **model_kwargs
         )
 
+        """ Make sure to use the configuration in the configuration file"""
+        if model_inputs.get("use_cache", None) is None:
+            model_inputs['use_cache'] = self._generation_kwargs.get("use_cache", None)
+
         if self._apply_model_parallel and unwrap_model(model).is_parallelizable:
             # if model is in parallel mode, move the tensors to the first device
             model_inputs = {


### PR DESCRIPTION
Make sure transformer return past_key_values,The code will judge whether it is a past process based on past_key_values, Thus affecting the shape of position_ids and input_ids.When use_cache is true, transformer will return past_key_values.