### PR TITLE
Fix IndexError when loading checkpoints

### DIFF
--- a/rl4lms/envs/text_generation/warm_start.py
+++ b/rl4lms/envs/text_generation/warm_start.py
@@ -97,7 +97,8 @@ class TrainerWarmStartMixin:
         except:
             os.makedirs(tracker.checkpoint_base_path)
             checkpoints = os.listdir(tracker.checkpoint_base_path)
-
+            
+        checkpoints = [cp for cp in checkpoints if "_" in cp]
         if len(checkpoints) == 0:
             return None, None
 


### PR DESCRIPTION
In  line104-105 of  rl4lms/envs/text_generation/warm_start.py, an IndexError  occurs if there exists filenames that do not contain "_", here is the crash:
 
```
 key=lambda ckpt: int(ckpt.split("_")[1]))
IndexError: list index out of range
```
Fixed by filtering filenames.